### PR TITLE
Top 100 btns+ls working throughout, multiple pgs genres

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -62,6 +62,10 @@ form {
   -webkit-text-fill-color: transparent;
 }
 
+.row {
+    margin-bottom: 0px !important;
+}
+
 #row-0 {
     margin-bottom: 12px;
     margin-top: auto;
@@ -77,7 +81,9 @@ form {
 
 .material-icons {
     color: goldenrod;
+    font-size: 3.2rem !important;
 }
+
 
 .search-form {
     padding: 15px;
@@ -141,9 +147,10 @@ form {
 }
 
 .secondary-data {
-    font-size: 22px;
+    font-size: 25px;
     font-family: "PT Sans", Verdana, Geneva;
     color: whitesmoke;
+    padding-left: 55px;
 }
 
 .gold {
@@ -179,6 +186,11 @@ form {
 @media screen and (max-width: 575px) { 
     * {
        overflow-x: hidden;
+    }
+
+    .secondary-data {
+        padding-left: 0px;
+        font-size: 18.1px;
     }
 }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,5 +1,6 @@
 html {
     height: 100%;
+    padding: 0;
 }
 
 body {
@@ -7,11 +8,7 @@ body {
     margin: 0;
     background-repeat: no-repeat;
     background-attachment: fixed;
-}
-
-#row-0 {
-    margin-bottom: 12px;
-    margin-top: auto;
+    padding: 0;
 }
 
 h2 {
@@ -43,6 +40,7 @@ form {
 .fifteen {
     flex: 1 15%;
 }
+
 .gold-and-silver-text {
   background: #8b4513;
   background-color: #8b4513;
@@ -62,6 +60,19 @@ form {
   background-repeat: repeat;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
+}
+
+#row-0 {
+    margin-bottom: 12px;
+    margin-top: auto;
+}
+
+#row-2 {
+    margin: 0px;
+}
+
+#row-3 {
+    margin: 0px;
 }
 
 .material-icons {
@@ -96,9 +107,13 @@ form {
     top: auto;
   }
 
+  ::placeholder { 
+      color: #474747;
+  }
+
 .main-title {
     font-size: 30px;
-    font-family: "Balsamiq Sans", 'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', Geneva, sans-serif;
+    font-family: "PT Sans", 'Lucida Sans', 'Verdana', Geneva, sans-serif;
     border-radius: 12px;
     border: 6px solid #0277bd;
     background-image: linear-gradient(45deg, #cacaca 0%, #afafaf 35%, #969696 75%);
@@ -107,13 +122,18 @@ form {
   }
 
 .modal-content, .modal-footer {
-    background-color: #2c2c2c;
+    background-color: #424242;
 }
 
 .modal-content p {
     font-size: 20px;
     font-family: "Asap", 'Lucida Sans', 'Lucida Sans Regular', 'Lucida Grande', Geneva, sans-serif;
     color: #FFD700;
+}
+
+#modal-close {
+    color: #9c9c9c;
+    font-family: "PT Sans", Verdana, Geneva;
 }
 
 .bottom {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -153,6 +153,36 @@ form {
     padding-left: 55px;
 }
 
+.new-div {
+    margin-top: 5px !important;
+    margin-bottom: 0px !important;
+    text-align: center;
+}
+
+.padding {
+    margin-left: 55px;
+}
+
+.style1 {
+    color: #0b69b1;
+}
+
+.style2 {
+    color: #0277bd;
+}
+
+.style3 {
+    color: #0288d1;
+}
+
+.style4 {
+    color:#2a67cf;
+}
+
+.style5 {
+    color: #1976d2 ;
+}
+
 .gold {
     font-size: 24px;
     color: #FFD700 !important;
@@ -191,6 +221,10 @@ form {
     .secondary-data {
         padding-left: 0px;
         font-size: 18.1px;
+    }
+
+    .padding {
+        margin-left: 0px;
     }
 }
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -75,7 +75,7 @@ function getGenres(genre) {
                     var genreRecallArr = genreData[i];
                     break;
                 } else {
-                    isNewSearch = true;
+                    isNewGenre = true;
                 }
             }
         }
@@ -299,6 +299,7 @@ function displayNamesViaGenre(data, genre) {
     // if the data returned has 50 results, show pg. 2 btn
     if (data.results.length === 50) {
         var pg2Button = $("<button></button>", { id: "page-2", class: "inline waves-effect waves-light btn-small" });
+        pg2Button.textContent = "Load next page"
         $(pg2Button).appendTo(secondaryDataDiv);
         var page = "2";
         $(document).on('click','#btnPg' + window.searchCount,function() { 
@@ -320,14 +321,14 @@ function displayNamesViaGenre(data, genre) {
 
     // add a new button
         var recentBtn = document.createElement("button");
-        var commaRemoved = genre.replace(",", "");
-        recentBtn.textContent = "" + commaRemoved;
+        var genresFormatted = data.queryString.replace('?genres=','');
+        recentBtn.textContent = "" + genresFormatted;
         var buttonDiv = document.querySelector("#button-div");
         recentBtn.setAttribute("id", "btn" + window.searchCount)
         recentBtn.classList = "inline waves-effect waves-light btn-small green lighten-2";
         buttonDiv.appendChild(recentBtn);
 
-    saveGenreListing(genreListing);
+    saveGenreListing(genreListing, data);
 
     // refresh and parse the titleData array
     genreData = localStorage.getItem("genreData")
@@ -369,11 +370,12 @@ function recallGenreSearch(arr) {
     var secondaryDataContent = arr.genreListing;
     secondaryDataEl.innerHTML = secondaryDataContent;
 
-    // if the data returned has 50 results, show pg. 2 btn
+    // if there's a page 2 saved, bring up a button for that page
     if (arr.genreListingPg2) {
         var pg2Button = $("<button></button>", { id: "page-2", class: "inline waves-effect waves-light btn-small" });
+        pg2Button.textContent = "Show next page"
         $(pg2Button).appendTo(secondaryDataDiv);
-        var page = "2";
+
         $(document).on('click','#btnPg' + window.searchCount,function() { 
             recDisplayPage2(arr);
         });     
@@ -411,6 +413,7 @@ function displayPage2(data, genre) {
     // if the data returned has 50 results, show pg. 2 btn
     if (data.results.length === 50) {
         var pg3Button = $("<button></button>", { id: "page-3", class: "inline waves-effect waves-light btn-small" });
+        pg3Button.textContent = "Load next page"
         $(pg3Button).appendTo(secondaryDataDiv);
         page = "3";
         $(document).on('click','#btnPg' + window.searchCount,function() { 
@@ -462,6 +465,7 @@ function recDisplayPage2(arr) {
 
     if (arr.genreListingPg3) {
         var pg3Button = $("<button></button>", { id: "page-3", class: "inline waves-effect waves-light btn-small" });
+        pg3Button.textContent = "Show next page"
         $(pg3Button).appendTo(secondaryDataDiv);
         $(document).on('click','#btnPg' + window.searchCount,function() { 
             recDisplayPage3(arr);
@@ -548,7 +552,7 @@ function displayGenresList() {
     $(secondaryData).appendTo(secondaryDataDiv);
     $(secondaryData2).html("<br>Horror<br>Music<br>Musical<br>Mystery<br>News<br>Reality-TV<br>Romance<br>Sci-Fi<br>Sport<br>Talk-Show<br>Thriller<br>War<br>Western");
     $(secondaryData2).appendTo(secondaryDataDiv2);
-    var closeBtn = $("<button></button>", { id: "close-btn", class: "inline waves-effect waves-light btn-small" });
+    var closeBtn = $("<button></button>", { id: "close-btn", class: "inline waves-effect waves-light btn-small light-blue darken-3" });
     $(closeBtn).html("Close");
     $(closeBtn).appendTo(secondaryBtnDiv);
 

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -6,11 +6,11 @@ $(document).ready(function(){
 //omdb key
 var apiKey = "90e49496";
 
-//var apiKey2 = "k_esgvbo9o";
-var apiKey2 = "k_n93546yy";
+var apiKey2 = "k_esgvbo9o";
+//var apiKey2 = "k_n93546yy";
 
 var searchCount = localStorage.getItem("searchCount");
-searchCount = parseInt(searchCount)
+searchCount = parseInt(searchCount);
 var isNewSearch = true;
 var isNewGenre = true;
 
@@ -27,25 +27,48 @@ if (window.searchCount === 0) {
     var genreElement = {
         results: []
     };
+    var mostPopular = []
+    var popularElement = {
+        items: []
+    }
+    var mostPopular2 = []
+    var popularElement2 = {
+        items: []
+    }
 } else {
     var titleData = localStorage.getItem("titleData");
     titleData = JSON.parse(titleData);
-    if (!titleData) {
-        var titleData = [];
-    }
-
+        if (!titleData) {
+            var titleData = [];
+        }
     var genreData = localStorage.getItem("genreData");
     genreData = JSON.parse(genreData);
-    if (!genreData) {
-        var genreData = [];
-    }
+        if (!genreData) {
+            var genreData = [];
+        }
+    var mostPopular = localStorage.getItem("mostPopular");
+    mostPopular = JSON.parse(mostPopular);
+        if (!mostPopular) {
+            var mostPopular = []
+            var popularElement = {
+                items: []
+            }
+        }
+    var mostPopular2 = localStorage.getItem("mostPopular2");
+    mostPopular2 = JSON.parse(mostPopular2);
+        if (!mostPopular2) {
+            var mostPopular2 = []
+            var popularElement2 = {
+                items: []
+            }
+        }
     var dataElement = {};
     var genreElement = {
         results: []
     };
 }
 
-// from stack overflow, for capitalizing
+// from stack overflow, for capitalizing first letter of strings
 function toTitleCase(str) {
     return str.replace(
       /\w\S*/g,
@@ -72,7 +95,7 @@ function getTitle(name) {
                                 console.log(data)
                                 displayMainTitle(data);
                             });
-                } else if (data.Error === "Movie not found!") { console.log("Error: No results found"); }
+                } else if (data.Error === "Movie not found!") { var error = "No results found"; displayError(error); }
             });
 }
 
@@ -81,6 +104,7 @@ function getTitle(name) {
 function getGenres(genre) {
     var apiUrlGenre = "https://imdb-api.com/API/AdvancedSearch/" + apiKey2 + "/?genres=" + genre + "&count=150";
     apiUrlGenre = apiUrlGenre.replace(/ /g, "");
+
         if (genreData.length > 0) {
             // confirm if genre(s) is(are) a new unique search 
             // and isn't(aren't) stored already by using a boolean
@@ -90,16 +114,16 @@ function getGenres(genre) {
                 string = string.replace('%20','');
                 string = string.replace('&count=150', '')
                 string = string.replace(/,/g, ', ')
-            // this may be redundant toTileCase
+                // this may be redundant toTileCase
                 string = toTitleCase(string);
                 string = string.replace(/\-[a-z]/g, match => match.toUpperCase());
-                if (string === genre) {
-                    isNewGenre = false;
-                    var genreRecallArr = genreData[i];
-                    break;
-                } else {
-                    isNewGenre = true;
-                }
+                    if (string === genre) {
+                        isNewGenre = false;
+                        var genreRecallArr = genreData[i];
+                        break;
+                    } else {
+                        isNewGenre = true;
+                    }
             }
         }
 
@@ -112,10 +136,41 @@ function getGenres(genre) {
                 if (data.results.length > 0) {
                     displayNamesViaGenre(data, genre);
                 } else { 
-                    console.log("Error: No results found")
+                    var error = "No results found"; 
+                    displayError(error);
                 }
             });
     } else { recallGenreSearch(genreRecallArr) };
+}
+// movies
+function getMostPopular() {
+    var apiMostPopular = "https://imdb-api.com/en/API/MostPopularMovies/" + apiKey2
+    fetch(apiMostPopular)
+            .then(response=> response.json())
+            .then(data=> {
+                console.log(data);
+                if (data.errorMessage === "") {
+                    displayMostPopular(data);
+                } else { 
+                    var error = "Fetch failed"; 
+                    displayError(error);
+                }
+            });
+}
+// shows
+function getMostPopular2() {
+    var apiMostPopular2 = "https://imdb-api.com/en/API/MostPopularTVs/" + apiKey2
+    fetch(apiMostPopular2)
+            .then(response=> response.json())
+            .then(data=> {
+                console.log(data);
+                if (data.errorMessage === "") {
+                    displayMostPopular2(data);
+                } else { 
+                    var error = "Fetch failed"; 
+                    displayError(error);
+                }
+            });
 }
 
 // used to submit the search for a title via omdb api
@@ -127,7 +182,8 @@ var formSubmitHandler = function(event) {
         getTitle(searchName);
         searchNameEl.value = "";
     } else {
-        alert("Please enter a title!");
+        var error = "Please enter a title!";
+        displayError(error)
     }
 };
 
@@ -138,11 +194,14 @@ var formSubmitHandler2 = function(event) {
     var searchGenre = searchNameEl.value.trim();
     if (searchGenre) {
         searchGenre = toTitleCase(searchGenre);
+        // for dashes and capitalizing first letter after them, such as
+        // in Sci-Fi, for some reason that formatting is important to the search
         searchGenre = searchGenre.replace(/\-[a-z]/g, match => match.toUpperCase());
         getGenres(searchGenre);
         searchNameEl.value = "";
     } else {
-        alert("Please enter a genre!");
+        var error = "Please enter a genre!";
+        displayError(error);
     }
 };
 
@@ -170,18 +229,23 @@ function displayMainTitle(data) {
     $(secondaryDataDiv).appendTo("#row-2");
     $(secondaryImgDiv).appendTo("#row-2");
     var secondaryData = $("<p></p>", { id: "secondary-data", class: "secondary-data" });
-    if (data.Ratings[1]) {
-    var rottenTom = JSON.stringify(data.Ratings[1]);
-    rottenTom = rottenTom.replace(/[{}]/g, '');
-    rottenTom = rottenTom.replace(/\"/g, "");
-    rottenTom = rottenTom.replace('Source:Rotten Tomatoes,Value:', '');
-    } else { var rottenTom = "Unavailable" }
-
-    $(secondaryData).html("<span class='gold'>Stars:</span> " + data.Actors + "<br><span class='gold'>Runtime:</span><em> " + data.Runtime + "</em><br><span class='gold'>Genres:</span> " + data.Genre + "<br><span class='gold'>Director:</span> " + data.Director +  "<br><span class='gold'>Content Rating:</span> " + data.Rated + "<br><span class='gold'>Awards:</span> " + data.Awards + "<br><span class='gold'>Rotten Tomatoes:</span> " + rottenTom);
+        if (data.Ratings[1]) {
+            var rottenTom = JSON.stringify(data.Ratings[1].Value);
+            rottenTom = rottenTom.replace(/[{}]/g, '');
+            rottenTom = rottenTom.replace(/\"/g, "");
+            var source = data.Ratings[1].Source;
+        } else { 
+            var rottenTom = "N/A" }
+            var source = "Rotten Tomatoes"
+        if (data.Ratings[1]) {
+            $(secondaryData).html("<span class='gold'>Stars:</span> " + data.Actors + "<br><span class='gold'>Runtime:</span><em> " + data.Runtime + "</em><br><span class='gold'>Genres:</span> " + data.Genre + "<br><span class='gold'>Director:</span> " + data.Director +  "<br><span class='gold'>Content Rating:</span> " + data.Rated + "<br><span class='gold'>Awards:</span> " + data.Awards + "<br><span class='gold'>" + source + ":</span> " + rottenTom);
+        } else {
+            $(secondaryData).html("<span class='gold'>Stars:</span> " + data.Actors + "<br><span class='gold'>Runtime:</span><em> " + data.Runtime + "</em><br><span class='gold'>Genres:</span> " + data.Genre + "<br><span class='gold'>Director:</span> " + data.Director +  "<br><span class='gold'>Content Rating:</span> " + data.Rated + "<br><span class='gold'>Awards:</span> " + data.Awards + "<br><span class='gold'>Rotten Tomatoes: </span>" + rottenTom)
+        }
     $(secondaryImgDiv).prepend('<img id="poster-img" src="' + data.Poster + '" width="285" height="440.39"/>');
     $("#poster-img").appendTo(secondaryImgDiv);
     $(secondaryData).appendTo(secondaryDataDiv);
-    $(secondaryDataDiv).append("<button data-target='plot' class='btn modal-trigger bottom'>Display plot summary</button>"); 
+    $(secondaryDataDiv).append("<button data-target='plot' class='padding btn modal-trigger bottom'>Display plot summary</button>"); 
     $("#para").html(data.Plot);
 
     function saveTitleData(data) {
@@ -216,6 +280,7 @@ function displayMainTitle(data) {
         var plot = data.Plot;
         dataElement.plot = plot;
 
+        dataElement.source = source;
         dataElement.rottenTom = rottenTom;
 
         localStorage.setItem("searchCount", window.searchCount)
@@ -241,10 +306,10 @@ function displayMainTitle(data) {
         var recentBtn = document.createElement("button");
         recentBtn.textContent = "" + data.Title;
         var buttonDiv = document.querySelector("#button-div");
-        // if isNewSearch increment the search count
-        window.searchCount += 1;
+    // if isNewSearch increment the search count
+    window.searchCount += 1;
         recentBtn.setAttribute("id", "btn" + window.searchCount)
-        recentBtn.classList = "inline waves-effect waves-light btn-small";
+        recentBtn.classList = "inline waves-effect waves-light btn-small clear";
         buttonDiv.appendChild(recentBtn);
     }
 
@@ -259,11 +324,6 @@ function displayMainTitle(data) {
     // create recent search buttons' "on click" assignments
     for (let i = 0; i < titleData.length; i++) {
         $(document).on('click','#btn' + titleData[i].searchCount,function() {
-            // remove whats on the page first
-            $(".main-title").remove();
-            $(".secondary-data").remove();
-            $(".secondary-img").remove();
-            
             recallTitleSearch(titleData[i]);
         });
     }
@@ -296,16 +356,16 @@ function recallTitleSearch(arr) {
     $(secondaryImgDiv).appendTo("#row-2");
     var secondaryData = $("<p></p>", { id: "secondary-data", class: "secondary-data" });
 
-    $(secondaryData).html("<span class='gold'>Stars:</span> " + arr.actors + "<br><span class='gold'>Runtime:</span><em> " + arr.runtime + "</em><br><span class='gold'>Genres:</span> " + arr.genres + "<br><span class='gold'>Director:</span> " + arr.director +  "<br><span class='gold'>Content Rating:</span> " + arr.rating + "<br><span class='gold'>Awards:</span> " + arr.awards + "<br><span class='gold'>Rotten Tomatoes:</span> " + arr.rottenTom);
+    $(secondaryData).html("<span class='gold'>Stars:</span> " + arr.actors + "<br><span class='gold'>Runtime:</span><em> " + arr.runtime + "</em><br><span class='gold'>Genres:</span> " + arr.genres + "<br><span class='gold'>Director:</span> " + arr.director +  "<br><span class='gold'>Content Rating:</span> " + arr.rating + "<br><span class='gold'>Awards:</span> " + arr.awards + "<br><span class='gold'>" + arr.source + ":</span> " + arr.rottenTom);
     $(secondaryImgDiv).prepend('<img id="poster-img" src="' + arr.image + '" width="285" height="440.39"/>');
     $("#poster-img").appendTo(secondaryImgDiv);
     $(secondaryData).appendTo(secondaryDataDiv);
-    $(secondaryDataDiv).append("<button data-target='plot' class='btn modal-trigger bottom'>Display plot summary</button>"); 
+    $(secondaryDataDiv).append("<button data-target='plot' class='padding btn modal-trigger bottom'>Display plot summary</button>"); 
     $("#para").html(arr.plot);
 }
 
+// this function is for displaying titles from a supplied genre(s)
 function displayNamesViaGenre(data, genre) {
-    // remove elements on the page first
     $(".main-title").remove();
     $(".secondary-data").remove();
     $(".secondary-img").remove()
@@ -329,9 +389,91 @@ function displayNamesViaGenre(data, genre) {
     $(secondaryData).appendTo(secondaryDataDiv);
     var secondaryDataEl = document.querySelector("#secondary-data");
     
-    // populate the list
+    var textMark = 0;
+    // populate the list, style it with different colors to create a smooth blend
     for (var i = 0; i < data.results.length && i < 50; i++) {
+        textMark = i;
         secondaryDataEl.innerHTML += "<a id='a" + i + "1'>" + data.results[i].title + "</a><br>";
+
+        switch(textMark) {
+            case 0: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 2: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 4: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 6: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 8: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 10:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 12:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 14:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 16:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 18:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 20:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 22:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 24:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 26:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 28:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 30:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 32:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 34:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 36:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 38:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 40:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 42:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 44:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 46:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 48:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            default: 
+                    $("#a" + i + "1").addClass("style1")
+        }
     }
 
     // increment the search count
@@ -361,7 +503,7 @@ function displayNamesViaGenre(data, genre) {
         recentBtn.textContent = "" + genresFormatted;
         var buttonDiv = document.querySelector("#button-div");
         recentBtn.setAttribute("id", "btn" + window.searchCount)
-        recentBtn.classList = "inline waves-effect waves-light btn-small green lighten-2";
+        recentBtn.classList = "inline waves-effect waves-light btn-small green lighten-2 clear";
         buttonDiv.appendChild(recentBtn);
 
     saveGenreListing();
@@ -375,8 +517,6 @@ function displayNamesViaGenre(data, genre) {
         var pg2Button = $("<button></button>", { id: "page-2", class: "inline waves-effect waves-light btn-small" });
         $(pg2Button).text("Load next page");
         $(pg2Button).appendTo(secondaryDataDiv);
-        var page = "2";
-        
         $(document).on('click','#page-2',function() { 
             recDisplayPage2(genreData[genreData.length - 1]);
         });     
@@ -390,8 +530,8 @@ function displayNamesViaGenre(data, genre) {
     }
 }
 
+// for recalling a previous search for genre(s)
 function recallGenreSearch(arr) {
-    // remove elements on the page first
     $(".main-title").remove();
     $(".secondary-data").remove();
     $(".secondary-img").remove()
@@ -409,6 +549,7 @@ function recallGenreSearch(arr) {
     string = string.replace('%20','');
     string = string.replace('%20','');
     string = string.replace('&count=150', '')
+    // fill the search description div
     $(mainTitleData).html("Search: " + string);
     $(mainTitleData).appendTo(mainTitleDiv);
 
@@ -419,13 +560,94 @@ function recallGenreSearch(arr) {
     $(secondaryData).appendTo(secondaryDataDiv);
     var secondaryDataEl = document.querySelector("#secondary-data");
 
-    var placekeeper = 0;
+    var placeKeeper = 0;
+    // style it with different colors to create a smooth blend
     for (let i = 0; i < arr.results.length && i < 50; i++) {
+        placeKeeper = i;
         secondaryDataEl.innerHTML += "<a id='a" + i + "1'>" + arr.results[i].title + "</a><br>";
-        placekeeper = i;
+
+        switch(placeKeeper) {
+            case 0: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 2: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 4: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 6: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 8: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 10:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 12:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 14:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 16:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 18:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 20:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 22:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 24: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 26: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 28: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 30: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 32: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 34:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 36:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 38:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 40:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 42:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 44:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 46:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 48:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            default: 
+                    $("#a" + i + "1").addClass("style1")
+        }
     }
     
-    if (placekeeper > 0 && placekeeper < 50) {
+    if (placeKeeper > 0 && placeKeeper < 50) {
         var pg1Button = $("<button></button>", { id: "page-1", class: "inline waves-effect waves-light btn-small" });
         $(pg1Button).text("Show next page");
         $(pg1Button).appendTo(secondaryDataDiv)
@@ -436,6 +658,7 @@ function recallGenreSearch(arr) {
     }
 }
 
+// display page 2 of a stored array from a genre(s) listing
 function recDisplayPage2(arr) {
     $("#secondary-data").remove();
     $("#page-1").remove();
@@ -449,13 +672,94 @@ function recDisplayPage2(arr) {
     $(secondaryData).appendTo(secondaryDataDiv);
     var secondaryDataEl = document.querySelector("#secondary-data");
 
-    var placekeeper = 0;
+    var placeKeeper = 0;
+    // style it with different colors to create a smooth blend
     for (let i = 50; i < arr.results.length && i < 100; i++) {
+        placeKeeper = i;
         secondaryDataEl.innerHTML += "<a id='a" + i + "1'>" + arr.results[i].title + "</a><br>";
-        placekeeper = i;
+
+        switch(placeKeeper) {
+            case 50: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 52: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 54: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 56: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 58: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 60:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 62:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 64:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 66:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 68:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 70:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 72:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 74: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 76: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 78: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 80: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 82: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 84:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 86:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 88:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 90:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 92:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 94:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 96:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 98:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            default: 
+                    $("#a" + i + "1").addClass("style1")
+        }
     }
 
-    if (placekeeper > 50 && placekeeper < 100) {
+    if (placeKeeper > 50 && placeKeeper < 100) {
         var pg2ButtonB = $("<button></button>", { id: "page-2b", class: "inline waves-effect waves-light btn-small" });
         $(pg2ButtonB).text("Show previous page");
         $(pg2ButtonB).appendTo(secondaryDataDiv);
@@ -473,6 +777,7 @@ function recDisplayPage2(arr) {
     }  
 }
 
+// display page 3 of a stored array from a genre(s) listing
 function recDisplayPage3(arr) {
     $("#secondary-data").remove();
     $("#page-1").remove();
@@ -486,13 +791,94 @@ function recDisplayPage3(arr) {
     $(secondaryData).appendTo(secondaryDataDiv);
     var secondaryDataEl = document.querySelector("#secondary-data");
     
-    var placekeeper = 0;
+    var placeKeeper = 0;
+    // style it with different colors to create a smooth blend
     for (let i = 100; i < arr.results.length && i < 150; i++) {
+        placeKeeper = i;
         secondaryDataEl.innerHTML += "<a id='a" + i + "1'>" + arr.results[i].title + "</a><br>";
-        placekeeper = i;
+
+        switch(placeKeeper) {
+            case 100: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 102: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 104: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 106: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 108: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 110:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 112:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 114:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 116:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 118:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 120:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 122:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 124: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 126: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 128: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 130: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 132: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 134:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 136:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 138:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 140:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 142:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 144:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 146:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 148:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            default: 
+                    $("#a" + i + "1").addClass("style1")
+        }
     }
 
-    if (placekeeper > 100 && placekeeper < 150) {
+    if (placeKeeper > 100 && placeKeeper < 150) {
         var pg3ButtonB = $("<button></button>", { id: "page-3b", class: "inline waves-effect waves-light btn-small" });
         $(pg3ButtonB).text("Show previous page");
         $(pg3ButtonB).appendTo(secondaryDataDiv);
@@ -503,37 +889,848 @@ function recDisplayPage3(arr) {
     }
 }
 
+// this is a sampler of genres for the user to use in their searches
 function displayGenresList() {
-    // remove elements on the page first
     $(".main-title").remove();
     $(".secondary-data").remove();
-    $(".secondary-img").remove()
+    $(".secondary-img").remove();
 
     // two formatted divs side by side which display a list of sample genres
+    var commasDiv = $("<div></div>", { id: "new-div", class: "secondary-data new-div col s12" });
+    $(commasDiv).appendTo("#row-2");
     var secondaryDataDiv = $("<div></div>", { id: "secondary-data-div", class: "secondary-data col s6" }); 
     $(secondaryDataDiv).appendTo("#row-2");
     var secondaryDataDiv2 = $("<div></div>", { id: "secondary-data-div-2", class: "secondary-data col s6" });
     $(secondaryDataDiv2).appendTo("#row-2");
+
     var secondaryData = $("<p></p>", { id: "secondary-data", class: "secondary-data gold center right" });
     var secondaryData2 = $("<p></p>", { id: "secondary-data-2", class: "secondary-data gold center left" });
+    var secondaryData3 = $("<p></p>", { id: "secondary-data-3", class: "secondary-data new-div" });
     var secondaryBtnDiv = $("<div></div>", { class: "secondary-data col s12" }); 
     $(secondaryBtnDiv).appendTo("#row-2");
 
     // list of genres
-    $(secondaryData).html("<span style='color: #9c9c9c'>Use commas for multiple genres: </span><br>Action<br>Adventure<br>Animation<br>Biography<br>Comedy<br>Crime<br>Documentary<br>Drama<br>Family<br>Fantasy<br>Film-Noir<br>Game-Show<br>History");
+    $(secondaryData3).appendTo(commasDiv);
+    $(secondaryData3).html("<span style='color: #9c9c9c'>Use commas (multiple genres)</span>");
+    $(secondaryData).html("Action<br>Adventure<br>Animation<br>Biography<br>Comedy<br>Crime<br>Documentary<br>Drama<br>Family<br>Fantasy<br>Film-Noir<br>Game-Show<br>History<br>");
     $(secondaryData).appendTo(secondaryDataDiv);
-    $(secondaryData2).html("<br>Horror<br>Music<br>Musical<br>Mystery<br>News<br>Reality-TV<br>Romance<br>Sci-Fi<br>Sport<br>Talk-Show<br>Thriller<br>War<br>Western");
+    $(secondaryData2).html("Horror<br>Music<br>Musical<br>Mystery<br>News<br>Reality-TV<br>Romance<br>Sci-Fi<br>Sport<br>Talk-Show<br>Thriller<br>War<br>Western<br>");
     $(secondaryData2).appendTo(secondaryDataDiv2);
     var closeBtn = $("<button></button>", { id: "close-btn", class: "inline waves-effect waves-light btn-small light-blue darken-3" });
     $(closeBtn).html("Close");
     $(closeBtn).appendTo(secondaryBtnDiv);
+    var clearBtn = $("<button></button>", {id: "clear-btn", class: "inline waves-effect waves-light btn-small light-blue darken-3" });
+    $(clearBtn).html("Clear buttons");
+    $(clearBtn).appendTo(secondaryBtnDiv);
 
     function clearGenresList() {
         $(".secondary-data").remove();
     }
 
     var closeBtnEl = document.querySelector("#close-btn");
-    closeBtnEl.addEventListener("click", clearGenresList);
+    closeBtnEl.addEventListener("click", clearGenresList);  
+    var clearBtnEl = document.querySelector("#clear-btn");
+    clearBtnEl.addEventListener("click", function() {
+        $(".clear").remove();
+        
+        localStorage.removeItem("titleData");
+        localStorage.removeItem("searchCount");
+        localStorage.removeItem("genreData");
+        localStorage.removeItem("mostPopular");
+        localStorage.removeItem("mostPopular2");
+
+        window.searchCount = 0;
+        var titleData = [];
+        var dataElement = {};
+        var genreData = [];
+        var genreElement = {
+            results: []
+        };
+        var mostPopular = []
+        var popularElement = {
+            items: []
+        }
+        var mostPopular2 = []
+        var popularElement2 = {
+            items: []
+        }
+    });
+}
+
+// this is a list of the most popular films being displayed via getMostPopular()
+function displayMostPopular(data) {
+    $(".main-title").remove();
+    $(".secondary-data").remove();
+    $(".secondary-img").remove()
+    $("#page-1").remove();
+    $("#page-2").remove();
+    $("#page-2b").remove();
+    $("#page-3").remove();
+    $("#page-3b").remove();
+
+    // one div showing search parameters
+    var mainTitleDiv = $("<div></div>", { id: "main-title", class: "main-title col s12 m6 l6 xl6" });
+    $(mainTitleDiv).appendTo("#row-1");
+    var mainTitleData = $("<p></p>", { id: "main-data", class: "main-data" });
+    $(mainTitleData).html("Search: Most Popular Films");
+    $(mainTitleData).appendTo(mainTitleDiv);
+
+    // another div showing a list of items
+    var secondaryDataDiv = $("<div></div>", { id: "secondary-data-div", class: "secondary-data col s12" }); 
+    $(secondaryDataDiv).appendTo("#row-2");
+    var secondaryData = $("<p></p>", { id: "secondary-data", class: "secondary-data" });
+    $(secondaryData).appendTo(secondaryDataDiv);
+    var secondaryDataEl = document.querySelector("#secondary-data");
+    
+    var textMark = 0;
+    // populate the list, style it with different colors to create a smooth blend
+    for (var i = 0; i < data.items.length && i < 100; i++) {
+        textMark = i;
+        secondaryDataEl.innerHTML += "<a id='a" + i + "1'>" + data.items[i].title + "</a><br>";
+
+        switch(textMark) {
+            case 0: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 2: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 4: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 6: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 8: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 10:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 12:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 14:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 16:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 18:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 20:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 22:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 24: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 26: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 28: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 30: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 32: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 34:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 36:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 38:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 40:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 42:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 44:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 46:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 48:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 50:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 52:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 54:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 56:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 58:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 60:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 62:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 64:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 66:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 68:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 70:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 72:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 74:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 76:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 78:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 80:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 82:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 84:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 86:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 88:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 90:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 92:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 94:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 96:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 98:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            default: 
+                    $("#a" + i + "1").addClass("style1")
+        }
+    }
+
+    // increment the search count
+    window.searchCount += 1;
+
+    function savePopularListing(data) {
+        localStorage.setItem("searchCount", window.searchCount)
+        var popularElement = {
+            items: []
+        }
+        // save the listing as an array to be stored
+            for (let i = 0; i < data.items.length; i++) {
+                popularElement.items.push(data.items[i]);
+            }
+        popularElement.searchCount = window.searchCount;
+        mostPopular.push(popularElement);
+        localStorage.setItem('mostPopular', JSON.stringify(mostPopular));
+    }
+
+    savePopularListing(data);
+
+    // refresh and parse the titleData array
+    mostPopular = localStorage.getItem("mostPopular")
+    mostPopular = JSON.parse(mostPopular);
+}
+
+// this is a listing of popular shows being displayed via getMostPopular2()
+function displayMostPopular2(data) {
+    $(".main-title").remove();
+    $(".secondary-data").remove();
+    $(".secondary-img").remove()
+    $("#page-1").remove();
+    $("#page-2").remove();
+    $("#page-2b").remove();
+    $("#page-3").remove();
+    $("#page-3b").remove();
+
+    // one div showing search parameters
+    var mainTitleDiv = $("<div></div>", { id: "main-title", class: "main-title col s12 m6 l6 xl6" });
+    $(mainTitleDiv).appendTo("#row-1");
+    var mainTitleData = $("<p></p>", { id: "main-data", class: "main-data" });
+    $(mainTitleData).html("Search: Most Popular Shows");
+    $(mainTitleData).appendTo(mainTitleDiv);
+
+    // another div showing a list of items
+    var secondaryDataDiv = $("<div></div>", { id: "secondary-data-div", class: "secondary-data col s12" }); 
+    $(secondaryDataDiv).appendTo("#row-2");
+    var secondaryData = $("<p></p>", { id: "secondary-data", class: "secondary-data" });
+    $(secondaryData).appendTo(secondaryDataDiv);
+    var secondaryDataEl = document.querySelector("#secondary-data");
+    
+    var textMark = 0;
+    // populate the list, style it with different colors to create a smooth blend
+    for (var i = 0; i < data.items.length && i < 100; i++) {
+        textMark = i;
+        secondaryDataEl.innerHTML += "<a id='a" + i + "1'>" + data.items[i].title + "</a><br>";
+
+        switch(textMark) {
+            case 0: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 2: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 4: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 6: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 8: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 10:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 12:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 14:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 16:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 18:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 20:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 22:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 24: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 26: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 28: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 30: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 32: $("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 34:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 36:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 38:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 40:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 42:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 44:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 46:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 48:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 50:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 52:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 54:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 56:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 58:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 60:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 62:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 64:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 66:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 68:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 70:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 72:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 74:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 76:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 78:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 80:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 82:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 84:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 86:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 88:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 90:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            case 92:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style3");
+                    break;
+            case 94:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style4");
+                    break;
+            case 96:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style5");
+                    break;
+            case 98:$("#a" + i + "1").removeClass();
+                    $("#a" + i + "1").addClass("style2");
+                    break;
+            default: 
+                    $("#a" + i + "1").addClass("style1")
+        }
+    }
+    // increment the search count
+    window.searchCount += 1;
+
+    function savePopularListing2(data) {
+        localStorage.setItem("searchCount", window.searchCount)
+        var popularElement2 = {
+            items: []
+        }
+        // save the listing as an array to be stored
+            for (let i = 0; i < data.items.length; i++) {
+                popularElement2.items.push(data.items[i]);
+            }
+        popularElement2.searchCount = window.searchCount;
+        mostPopular2.push(popularElement2);
+        localStorage.setItem('mostPopular2', JSON.stringify(mostPopular2));
+    }
+
+    savePopularListing2(data);
+
+    // refresh and parse the titleData array
+    mostPopular2 = localStorage.getItem("mostPopular2")
+    mostPopular2 = JSON.parse(mostPopular2);
+}
+
+// this function recalls the list of either popular films 
+// or shows depending on the variable show which is passed 
+function recallPopular(show, arr) {
+    $(".main-title").remove();
+    $(".secondary-data").remove();
+    $(".secondary-img").remove()
+    $("#page-1").remove();
+    $("#page-2").remove();
+    $("#page-2b").remove();
+    $("#page-3").remove();
+    $("#page-3b").remove();
+
+    // one div showing search parameters
+    var mainTitleDiv = $("<div></div>", { id: "main-title", class: "main-title col s12 m6 l6 xl6" });
+    $(mainTitleDiv).appendTo("#row-1");
+    var mainTitleData = $("<p></p>", { id: "main-data", class: "main-data" });
+    if (show === true) {
+        $(mainTitleData).html("Search: Most Popular Show");
+    } else { 
+        $(mainTitleData).html("Search: Most Popular Film")}
+    $(mainTitleData).appendTo(mainTitleDiv);
+
+    // another div showing a list of items
+    var secondaryDataDiv = $("<div></div>", { id: "secondary-data-div", class: "secondary-data col s12" }); 
+    $(secondaryDataDiv).appendTo("#row-2");
+    var secondaryData = $("<p></p>", { id: "secondary-data", class: "secondary-data" });
+    $(secondaryData).appendTo(secondaryDataDiv);
+    var secondaryDataEl = document.querySelector("#secondary-data");
+    
+    var textMark = 0;
+    // populate the list, style it with different colors to create a smooth blend.
+    // pass in show to tell the app whether this is a movie or show that it is recalling 
+    if (show === true) { // show
+        for (var i = 0; i < mostPopular2[0].items.length; i++) {
+            textMark = i;
+            secondaryDataEl.innerHTML += "<a id='a" + i + "1'>" + mostPopular2[0].items[i].title + "</a><br>";
+    
+            switch(textMark) {
+                case 0: $("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 2: $("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 4: $("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 6: $("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 8: $("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 10:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 12:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 14:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 16:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 18:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 20:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 22:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 24:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 26:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 28:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 30:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 32:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 34:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 36:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 38:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 40:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 42:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 44:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 46:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 48:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 50:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 52:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 54:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 56:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 58:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 60:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 62:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 64:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 66:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 68:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 70:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 72:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 74:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 76:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 78:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 80:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 82:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 84:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 86:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 88:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 90:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 92:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 94:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 96:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 98:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                default: 
+                        $("#a" + i + "1").addClass("style1")
+            }
+        }
+    } else { // film
+        for (var i = 0; i < mostPopular[0].items.length; i++) {
+            textMark = i;
+            secondaryDataEl.innerHTML += "<a id='a" + i + "1'>" + mostPopular[0].items[i].title + "</a><br>";
+    
+            switch(textMark) {
+                case 0: $("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 2: $("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 4: $("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 6: $("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 8: $("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 10:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 12:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 14:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 16:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 18:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 20:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 22:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 24: $("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 26: $("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 28: $("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 30: $("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 32: $("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 34:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 36:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 38:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 40:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 42:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 44:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 46:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 48:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 50:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 52:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 54:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 56:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 58:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 60:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 62:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 64:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 66:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 68:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 70:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 72:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 74:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 76:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 78:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 80:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 82:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 84:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 86:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 88:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 90:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                case 92:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style3");
+                        break;
+                case 94:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style4");
+                        break;
+                case 96:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style5");
+                        break;
+                case 98:$("#a" + i + "1").removeClass();
+                        $("#a" + i + "1").addClass("style2");
+                        break;
+                default: 
+                        $("#a" + i + "1").addClass("style1")
+            }
+        }
+    }
 }
 
 // these functions were a quick solution but involve changing our 'save' code
@@ -556,6 +1753,24 @@ function displayGenresList() {
 //      displayMainTitle(movie);
 //  }
 
+function displayError(error) { 
+    $(".main-title").remove();
+    $(".secondary-data").remove();
+    $(".secondary-img").remove();
+    $("#page-1").remove();
+    $("#page-2").remove();
+    $("#page-2b").remove();
+    $("#page-3").remove();
+    $("#page-3b").remove();
+
+    // one div showing errors
+    var mainTitleDiv = $("<div></div>", { id: "main-title", class: "main-title col s12 m6 l6 xl6" });
+    $(mainTitleDiv).appendTo("#row-1");
+    var mainTitleData = $("<p></p>", { id: "main-data", class: "main-data" });
+    $(mainTitleData).html("<em>Error:</em> " + error);
+    $(mainTitleData).appendTo(mainTitleDiv);
+}
+
 function loadButtonsFirst() {
 // this function loads the buttons if there are any in LS on page load
     if (window.searchCount > 0) {
@@ -565,7 +1780,7 @@ function loadButtonsFirst() {
             recentBtn.textContent = "" + titleData[i].title;
             var buttonDiv = document.querySelector("#button-div");
             recentBtn.setAttribute("id", "btn" + (titleData[i].searchCount));
-            recentBtn.classList = "inline waves-effect waves-light btn-small";
+            recentBtn.classList = "inline waves-effect waves-light btn-small clear";
             buttonDiv.appendChild(recentBtn);
                 // jquery button assignments 
                 $(document).on('click','#btn' + (titleData[i].searchCount),function() {
@@ -587,7 +1802,7 @@ function loadButtonsFirst() {
             recentBtn.textContent = "" + string;
             var buttonDiv = document.querySelector("#button-div");
             recentBtn.setAttribute("id", "btn" + (genreData[i].searchCount));
-            recentBtn.classList = "inline waves-effect waves-light btn-small green lighten-2"
+            recentBtn.classList = "inline waves-effect waves-light btn-small green lighten-2 clear"
             buttonDiv.appendChild(recentBtn);
                 // jquery button assignments 
                 $(document).on('click','#btn' + (genreData[i].searchCount),function() {
@@ -597,7 +1812,33 @@ function loadButtonsFirst() {
         }
     }
 }
-// ^
+
+// if mostPopular exists in LS recall, otherwise get new listing
+var newBtn = $("<button></button>", { id: "most-popular", class: "inline waves-effect waves-light btn-small cyan darken-3" });
+$(newBtn).html("Top 100 Films");
+$(newBtn).appendTo("#button-div"); 
+$(newBtn).on("click", function() {
+    if (mostPopular.length > 0) {
+        var show = false;
+        recallPopular(show, mostPopular);
+    } else {
+        getMostPopular();
+    }
+});
+
+// if mostPopular2 exists in LS recall, otherwise get new listing
+var newBtn = $("<button></button>", { id: "most-popular2", class: "inline waves-effect waves-light btn-small teal darken-2" });
+$(newBtn).html("Top 100 Shows");
+$(newBtn).appendTo("#button-div"); 
+$(newBtn).on("click", function() {
+    if (mostPopular2.length > 0) {
+        var show = true;
+        recallPopular(show, mostPopular2);
+    } else {
+        getMostPopular2();
+    }
+});
+
 loadButtonsFirst();
 
 // query selectors for the search form

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
     <!-- Buttons Row Structure -->
     <div id="row-3" class="row">
         <div id="button-div" class="button-div col s12">
-            <button id="genres-ideas" class="inline waves-effect waves-light btn-small">Genres</button>
+            <button id="genres-ideas" class="inline waves-effect waves-light btn-small light-blue darken-3">Genres</button>
         </div>
     </div>
 


### PR DESCRIPTION
Added Top 100 Shows and Top 100 Films buttons, they get stored in local storage as well as all genre and title searches. Also added show next and previous page buttons for genre listings, allowing up to 3 pages of content. Allowed the user from within the genre sampler button display to clear their cached buttons and clear all local storage values. Made various formatting adjustments, fixed bugs for example notably with the formatting of genre searches concerning multiple genres to capitalize and get rid of spaces, which seems to affect the results. Also fixed small display bugs concerning data points such as whether a datapoint is a metacritic or a rotten tomatoes rating, and to display that accordingly, or if that data doesn't exist simply list as unavailable.